### PR TITLE
Fixed SMS plotting in 74X

### DIFF
--- a/PlotsSMS/python/inputFile.py
+++ b/PlotsSMS/python/inputFile.py
@@ -29,7 +29,9 @@ class inputFile():
             if tmpLINE[0] != "HISTOGRAM": continue
             fileIN.close()
             rootFileIn = rt.TFile.Open(tmpLINE[1])
-            return {'histogram': rootFileIn.Get(tmpLINE[2])}
+            histo = rootFileIn.Get(tmpLINE[2])
+            histo.SetDirectory(0)
+            return {'histogram': histo}
             
     def findEXPECTED(self, fileName):
         fileIN = open(fileName)        

--- a/PlotsSMS/python/sms.py
+++ b/PlotsSMS/python/sms.py
@@ -232,10 +232,10 @@ class sms():
 #        self.Ymin = 12.5
 #        self.Ymax = 537.5
         self.Xmin = 100.0
-        self.Xmax = 900.0
+        self.Xmax = 1200.0
         self.Ymin = 0.00
-        self.Ymax = 500.0
-        self.Zmin = 0.02
+        self.Ymax = 650.0
+        self.Zmin = 0.0005
         self.Zmax = 100
         # produce sparticle
         self.sParticle = "m#kern[0.1]{_{#lower[-0.12]{#tilde{t}}}} [GeV]"


### PR DESCRIPTION
inputFile.py adjusted so that sms plotting works in 74X. (Histogram object was not retained when the input root file was closed.)
sms.py editted so that T2tt plots with the correct range.